### PR TITLE
use le extended commands set if supported

### DIFF
--- a/aioblescan/__main__.py
+++ b/aioblescan/__main__.py
@@ -110,9 +110,9 @@ conn,btctrl = event_loop.run_until_complete(fac)
 btctrl.process=my_process
 if opts.advertise:
     command = aiobs.HCI_Cmd_LE_Advertise(enable=False)
-    btctrl.send_command(command)
+    event_loop.run_until_complete(btctrl.send_command(command))
     command = aiobs.HCI_Cmd_LE_Set_Advertised_Params(interval_min=opts.advertise,interval_max=opts.advertise)
-    btctrl.send_command(command)
+    event_loop.run_until_complete(btctrl.send_command(command))
     if opts.url:
         myeddy = EddyStone(param=opts.url)
     else:
@@ -120,12 +120,12 @@ if opts.advertise:
     if opts.txpower:
         myeddy.power=opts.txpower
     command = aiobs.HCI_Cmd_LE_Set_Advertised_Msg(msg=myeddy)
-    btctrl.send_command(command)
+    event_loop.run_until_complete(btctrl.send_command(command))
     command = aiobs.HCI_Cmd_LE_Advertise(enable=True)
-    btctrl.send_command(command)
+    event_loop.run_until_complete(btctrl.send_command(command))
 
 #Probe
-btctrl.send_scan_request()
+event_loop.run_until_complete(btctrl.send_scan_request())
 try:
     # event_loop.run_until_complete(coro)
     event_loop.run_forever()
@@ -133,8 +133,8 @@ except KeyboardInterrupt:
     print('keyboard interrupt')
 finally:
     print('closing event loop')
-    btctrl.stop_scan_request()
+    event_loop.run_until_complete(btctrl.stop_scan_request())
     command = aiobs.HCI_Cmd_LE_Advertise(enable=False)
-    btctrl.send_command(command)
+    event_loop.run_until_complete(btctrl.send_command(command))
     conn.close()
     event_loop.close()

--- a/aioblescan/__main__.py
+++ b/aioblescan/__main__.py
@@ -64,11 +64,9 @@ except Exception as e:
     parser.error("Error: " + str(e))
     sys.exit()
 
-def my_process(data):
+def my_process(ev, extra_data):
     global opts
 
-    ev=aiobs.HCI_Event()
-    xx=ev.decode(data)
     if opts.mac:
         goon = False
         mac= ev.retrieve("peer")

--- a/aioblescan/aioblescan.py
+++ b/aioblescan/aioblescan.py
@@ -820,8 +820,8 @@ class HCI_Cmd_LE_Set_Scan_Params(HCI_Command):
                                                          2 => Similar to 0. Some directed advertising may be received.
                                                          3 => Similar to 1. Some directed advertising may be received.
         :type filter: int
-        :returns: HCI_Cmd_LE_Scan_Params instance.
-        :rtype: HCI_Cmd_LE_Scan_Params
+        :returns: HCI_Cmd_LE_Set_Scan_Params instance.
+        :rtype: HCI_Cmd_LE_Set_Scan_Params
 
     """
 

--- a/aioblescan/aioblescan.py
+++ b/aioblescan/aioblescan.py
@@ -1334,25 +1334,33 @@ class BLEScanRequester(asyncio.Protocol):
         command=HCI_Cmd_Read_Local_Supported_Commands()
         self.transport.write(command.encode())
 
-        command=HCI_Cmd_LE_Set_Scan_Params()
-        self.transport.write(command.encode())
-
     def connection_lost(self, exc):
         super().connection_lost(exc)
 
-    def send_scan_request(self):
+    async def send_scan_request(self):
         '''Sending LE scan request'''
+        await self._initialized.wait()
+
+        command=HCI_Cmd_LE_Set_Scan_Params()
+        self._send_command_no_wait(command)
+
         command=HCI_Cmd_LE_Scan_Enable(True,False)
-        self.transport.write(command.encode())
+        return self._send_command_no_wait(command)
 
-    def stop_scan_request(self):
+    async def stop_scan_request(self):
         '''Sending LE scan request'''
-        command=HCI_Cmd_LE_Scan_Enable(False,False)
-        self.transport.write(command.encode())
+        await self._initialized.wait()
 
-    def send_command(self,command):
+        command=HCI_Cmd_LE_Scan_Enable(False,False)
+        return self._send_command_no_wait(command)
+
+    def _send_command_no_wait(self,command):
+        return self.transport.write(command.encode())
+
+    async def send_command(self,command):
         '''Sending an arbitrary command'''
-        self.transport.write(command.encode())
+        await self._initialized.wait()
+        return self._send_command_no_wait(command)
 
     def data_received(self, packet):
         ev=HCI_Event()

--- a/aioblescan/aioblescan.py
+++ b/aioblescan/aioblescan.py
@@ -1341,7 +1341,16 @@ class BLEScanRequester(asyncio.Protocol):
         self.transport.write(command.encode())
 
     def data_received(self, packet):
-        self.process(packet)
+        ev=HCI_Event()
+        extra_data=ev.decode(packet)
+        if ev.payload[0].val == b'\x0e':
+            cc=ev.retrieve("Command Completed")[0]
+            cmd=cc.retrieve(OgfOcf)[0]
+            opcode=(ord(cmd.ogf) << 10) | ord(cmd.ocf)
+            resp=cc.retrieve('resp code')[0]
+            return
 
-    def default_process(self,data):
+        self.process(ev, extra_data)
+
+    def default_process(self,ev,extra_data):
         pass


### PR DESCRIPTION
On some devices, observed on RTL8822CE and Intel AX201, issue 5.0 LE commands while bluetoothd has preconfigured 5.1 LE extended commands may cause **Command Disallowed** error and fails following scan:
```
@ RAW Open: python3 (privileged) version 2.22 {0x0003} [hci0] 4.021364
< HCI Command: LE Set Scan Parameters (0x08|0x000b) plen 7 #1 [hci0] 4.021692
        Type: Passive (0x00)
        Interval: 10.000 msec (0x0010)
        Window: 10.000 msec (0x0010)
        Own address type: Public (0x00)
        Filter policy: Accept all advertisement (0x00)
> HCI Event: Command Complete (0x0e) plen 4 #2 [hci0] 4.139014
      LE Set Scan Parameters (0x08|0x000b) ncmd 1
        Status: Command Disallowed (0x0c)
< HCI Command: LE Set Scan Enable (0x08|0x000c) plen 2 #3 [hci0] 4.139129
        Scanning: Enabled (0x01)
        Filter duplicates: Disabled (0x00)
> HCI Event: Command Complete (0x0e) plen 4 #4 [hci0] 4.139962
      LE Set Scan Enable (0x08|0x000c) ncmd 1
        Status: Command Disallowed (0x0c)
< HCI Command: LE Set Scan Enable (0x08|0x000c) plen 2 #5 [hci0] 121.924256
        Scanning: Disabled (0x00)
        Filter duplicates: Disabled (0x00)
@ RAW Close: python3
```

This pull request adds **HCI_Read_Local_Supported_Commands**, **HCI_LE_Set_Extended_Scan_Params** and **HCI_LE_Set_Extended_Scan_Enable** to the support list and refactor a bit to ensure all further commands will only be issued after full initialized.